### PR TITLE
Make multiple metrics on one line explicit.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ Once data is delivered, l2met extracts and parses the individual log lines using
 L2met uses convention over configuration to build metrics.
 
 ```
-measure="myapp" view=20 db=10
+measure="myapp" measure.view=20 measure.db=10
 ```
 Metrics Produced:
 

--- a/store/bucket.go
+++ b/store/bucket.go
@@ -118,9 +118,12 @@ func NewBucket(token string, rdr *bufio.Reader) <-chan *Bucket {
 					continue
 				}
 				var name string
-				if k == "val" {
+				switch {
+				case strings.HasPrefix(k, "measure."):
+					name = measure + "." + k[8:]
+				case k == "val":
 					name = measure
-				} else {
+				default:
 					name = measure + "." + k
 				}
 				k := BKey{Token: token, Name: name, Source: source, Time: t}


### PR DESCRIPTION
The multi-metric support added as part of #27 considered anything matching `key=floatval` on the same line as `measure=foo` to be a metric in the form `foo.key` with a value of `floatval`.

This PR changes that a bit to make things more explicit: things matching `measure.key=floatval` on the same line as `measure=foo` will be considered to be a metric in the form `foo.key` with a value of `floatval`.

My motivation is cutting down on measurements sent to librato for metrics that won't be useful which translates primarily to lower cost.
