### PR TITLE
Multi metrics

### DIFF
--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -72,13 +73,10 @@ func NewBucket(tok string, rdr *bufio.Reader, opts map[string][]string) <-chan *
 					bucket.Vals = []float64{val}
 					c <- bucket
 				default:
-					if len(k) < len("measure.") {
+					if !strings.HasPrefix(k, "measure.") {
 						break
 					}
-					if k[0:len("measure.")] != "measure." {
-						break
-					}
-					name := k[len("measure."):len(k)]
+					name := k[8:]
 					val := parseVal(v)
 					id := &Id{ts, res, tok, name, src}
 					bucket := &Bucket{Id: id}

--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -49,10 +49,7 @@ func NewBucket(token string, rdr *bufio.Reader, opts map[string][]string) <-chan
 				continue
 			}
 
-			source, ok := d["source"]
-			if !ok {
-				source = ""
-			}
+			source := d["source"]
 
 			t, err := logLine.Time()
 			if err != nil {

--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -31,7 +31,7 @@ func NewBucket(token string, rdr *bufio.Reader, opts map[string][]string) <-chan
 		defer close(c)
 		lp := logplex.NewReader(rdr)
 		for {
-			packet, err := lp.ReadMsg()
+			logLine, err := lp.ReadMsg()
 			if err != nil {
 				if err == io.EOF {
 					break
@@ -39,7 +39,7 @@ func NewBucket(token string, rdr *bufio.Reader, opts map[string][]string) <-chan
 				fmt.Printf("at=logplex-error err=%s\n", err)
 				return
 			}
-			d, err := encoding.ParseMsgData(packet.Msg)
+			d, err := encoding.ParseMsgData(logLine.Msg)
 			if err != nil {
 				continue
 			}
@@ -54,7 +54,7 @@ func NewBucket(token string, rdr *bufio.Reader, opts map[string][]string) <-chan
 				source = ""
 			}
 
-			t, err := packet.Time()
+			t, err := logLine.Time()
 			if err != nil {
 				fmt.Printf("at=time-error error=%s\n", err)
 				continue

--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -24,7 +24,7 @@ type Bucket struct {
 }
 
 //TODO(ryandotsmith): NewBucket should be broken up. This func is too big.
-func NewBucket(token string, rdr *bufio.Reader, opts map[string][]string) <-chan *Bucket {
+func NewBucket(tok string, rdr *bufio.Reader, opts map[string][]string) <-chan *Bucket {
 	//TODO(ryandotsmith): Can we eliminate the magical number?
 	buckets := make(chan *Bucket, 10000)
 	go func(c chan<- *Bucket) {
@@ -39,50 +39,67 @@ func NewBucket(token string, rdr *bufio.Reader, opts map[string][]string) <-chan
 				fmt.Printf("at=logplex-error err=%s\n", err)
 				return
 			}
-			d, err := encoding.ParseMsgData(logLine.Msg)
+
+			logData, err := encoding.ParseMsgData(logLine.Msg)
 			if err != nil {
 				continue
 			}
 
-			measure, ok := d["measure"]
-			if !ok {
-				continue
-			}
-
-			source := d["source"]
-
-			t, err := logLine.Time()
+			ts, err := logLine.Time()
 			if err != nil {
 				fmt.Printf("at=time-error error=%s\n", err)
 				continue
 			}
 
-			resTmp, ok := opts["resolution"]
+			resQuery, ok := opts["resolution"]
 			if !ok {
-				resTmp = []string{"60000"}
+				resQuery = []string{"60000"}
 			}
-			resolution, err := strconv.Atoi(resTmp[0])
+			resTmp, err := strconv.Atoi(resQuery[0])
 			if err != nil {
 				continue
 			}
-			t = utils.RoundTime(t, time.Millisecond*time.Duration(resolution))
+			res := time.Duration(resTmp)
+			ts = utils.RoundTime(ts, time.Millisecond*res)
+			src := logData["source"]
 
-			val := float64(1)
-			tmpVal, present := d["val"]
-			if present {
-				v, err := strconv.ParseFloat(tmpVal, 64)
-				if err == nil {
-					val = v
+			for k, v := range logData {
+				switch k {
+				case "measure":
+					val := parseVal(logData["val"])
+					id := &Id{ts, res, tok, v, src}
+					bucket := &Bucket{Id: id}
+					bucket.Vals = []float64{val}
+					c <- bucket
+				default:
+					if len(k) < len("measure.") {
+						break
+					}
+					if k[0:len("measure.")] != "measure." {
+						break
+					}
+					name := k[len("measure."):len(k)]
+					val := parseVal(v)
+					id := &Id{ts, res, tok, name, src}
+					bucket := &Bucket{Id: id}
+					bucket.Vals = []float64{val}
+					c <- bucket
 				}
 			}
-
-			k := &Id{Token: token, Name: measure, Source: source, Time: t, Resolution: time.Duration(resolution)}
-			b := &Bucket{Id: k}
-			b.Vals = append(b.Vals, val)
-			c <- b
 		}
 	}(buckets)
 	return buckets
+}
+
+func parseVal(s string) float64 {
+	val := float64(1)
+	if len(s) > 0 {
+		v, err := strconv.ParseFloat(s, 64)
+		if err == nil {
+			val = v
+		}
+	}
+	return val
 }
 
 // Adding bucket a to bucket b copies the vals of bucket b and

--- a/receiver/receiver_test.go
+++ b/receiver/receiver_test.go
@@ -32,8 +32,8 @@ func TestReceive(t *testing.T) {
 	time.Sleep(recv.FlushInterval * 2)
 
 	var buckets []*bucket.Bucket
-	for bucket := range store.Scan("not important") {
-		buckets = append(buckets, bucket)
+	for b := range store.Scan("not important") {
+		buckets = append(buckets, b)
 	}
 
 	if len(buckets) != 1 {
@@ -62,8 +62,8 @@ func TestReceiveOpts(t *testing.T) {
 	time.Sleep(recv.FlushInterval * 2)
 
 	var buckets []*bucket.Bucket
-	for bucket := range store.Scan("not important") {
-		buckets = append(buckets, bucket)
+	for b := range store.Scan("not important") {
+		buckets = append(buckets, b)
 	}
 
 	if len(buckets) != 1 {
@@ -81,5 +81,38 @@ func TestReceiveOpts(t *testing.T) {
 
 	if testBucket.Id.Time.Second() != 1 {
 		t.FailNow()
+	}
+}
+
+func TestReceiveMultiMetrics(t *testing.T) {
+	store, recv := makeReceiver()
+	recv.FlushInterval = time.Millisecond
+	recv.Start()
+	defer recv.Stop()
+
+	opts := map[string][]string{"resolution": []string{"1000"}}
+	msg := []byte("95 <190>1 2013-03-27T00:00:01+00:00 hostname token shuttle - - measure=hello val=10 measure.db=10\n")
+	recv.Receive("123", msg, opts)
+	time.Sleep(recv.FlushInterval * 2)
+
+	var buckets []*bucket.Bucket
+	for b := range store.Scan("not important") {
+		buckets = append(buckets, b)
+	}
+
+	expectedLength := 2
+	actualLength := len(buckets)
+	if actualLength != expectedLength {
+		t.Errorf("expected=%d actual=%d\n", expectedLength, actualLength)
+	}
+
+	//the log line above has two measurements with values of 10.
+	actualSum := float64(0)
+	for i := range buckets {
+		actualSum += buckets[i].Sum()
+	}
+	expectedSum := float64(20)
+	if actualSum != expectedSum {
+		t.Errorf("expected=%d actual=%d\n", expectedSum, actualSum)
 	}
 }


### PR DESCRIPTION
Motivation:

We want to be able to specify multiple measurements on a single line so as not to have to pay the (albeit low) overhead of writing to stdout. However, we don't want to take every k=v under the sun. L2met has always forced you to think about the things your are measuring and this feature does not regress in that regard.

Example:

```
echo 'measure=hello val=10 measure.world=10' | log-shuttle
```

This will result in 2 buckets:

bucket1 = {name=hello, vals=[10], ...}
bucket2 = {name=world vals=[10], ...}

Thus you can measure multiple things provided the key is prefixed with `measure.`.
