### PR TITLE
special case heroku router

### DIFF
--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -52,6 +52,16 @@ func NewBucket(tok string, rdr *bufio.Reader, opts map[string][]string) <-chan *
 				continue
 			}
 
+			//Special case the Heroku router.
+			//In this case, we will massage logData
+			//to include connect, service, and bytes.
+			if string(logLine.Host) == "router" {
+				prefix := logData["host"] + ".measure."
+				logData[prefix+"connect"] = logData["connect"]
+				logData[prefix+"service"] = logData["service"]
+				logData[prefix+"bytes"] = logData["bytes"]
+			}
+
 			resQuery, ok := opts["resolution"]
 			if !ok {
 				resQuery = []string{"60000"}

--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -55,9 +55,9 @@ func NewBucket(tok string, rdr *bufio.Reader, opts map[string][]string) <-chan *
 			//Special case the Heroku router.
 			//In this case, we will massage logData
 			//to include connect, service, and bytes.
-			if string(logLine.Host) == "router" {
+			if string(logLine.User) == "router" {
 				prefix := "measure."
-				if len(logData["host"]) == 0 {
+				if len(logData["host"]) > 0 {
 					prefix += (logData["host"] + ".")
 				}
 				if len(logData["connect"]) > 0 {

--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -56,10 +56,19 @@ func NewBucket(tok string, rdr *bufio.Reader, opts map[string][]string) <-chan *
 			//In this case, we will massage logData
 			//to include connect, service, and bytes.
 			if string(logLine.Host) == "router" {
-				prefix := logData["host"] + ".measure."
-				logData[prefix+"connect"] = logData["connect"]
-				logData[prefix+"service"] = logData["service"]
-				logData[prefix+"bytes"] = logData["bytes"]
+				prefix := "measure."
+				if len(logData["host"]) == 0 {
+					prefix += (logData["host"] + ".")
+				}
+				if len(logData["connect"]) > 0 {
+					logData[prefix+"connect"] = strings.Replace(logData["connect"], "ms", "", -1)
+				}
+				if len(logData["service"]) > 0 {
+					logData[prefix+"service"] = strings.Replace(logData["service"], "ms", "", -1)
+				}
+				if len(logData["bytes"]) > 0 {
+					logData[prefix+"bytes"] = logData["bytes"]
+				}
 			}
 
 			resQuery, ok := opts["resolution"]

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## 0.4 2013-04-02
+
+* [Heroku Router](https://github.com/ryandotsmith/l2met#heroku-router)
+
 ## 0.3 2013-04-02
 
 * [Multi-metrics](https://github.com/ryandotsmith/l2met#multi-metrics)

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,7 @@ Metrics Produced:
 
 * [High resolution buckets](#high-resolution-buckets)
 * [Multi-metrics](#multi-metrics)
+* [Heroku Router](#heroku-router)
 * Librato Outlet
 * Graphite Outlet
 
@@ -63,6 +64,24 @@ bucket1 = {name=hello, vals=[10], ...}
 bucket2 = {name=world vals=[10], ...}
 
 Thus you can measure multiple things provided the key is prefixed with `measure.`.
+
+### Heroku Router
+
+The Heroku router has a log line convention described [here](https://devcenter.heroku.com/articles/http-routing#heroku-router-log-format)
+
+This feature will read the User field in the syslog packet looking for the string "router." If a match is had, we will parse the structured data and massage it to match the l2met convention. Furthermore, we will prefix the measurement name with the parsed host field in the log line.
+
+Example:
+
+```
+path=/logs host=test.l2met.net connect=1ms service=2ms bytes=0
+```
+
+Would produce the bucket:
+
+bucket1 = {name="test.l2met.net.connect" vals=[1]}
+bucket2 = {name="test.l2met.net.service" vals=[2]}
+bucket3 = {name="test.l2met.net.bytes" vals=[0]}
 
 ## Setup
 


### PR DESCRIPTION
The Heroku router has a log line convention described [here](https://devcenter.heroku.com/articles/http-routing#heroku-router-log-format)

This feature will read the Host field in the syslog packet looking for the string "router." If a match is had, we will parse the structured data and massage it to match the l2met convention. Furthermore, we will prefix the measurement name with the parsed host field in the log line.

Example:

```
at=info method=POST path=/logs?resolution=1000 host=l2met-vis.herokuapp.com request_id=3f791410bc9610716113a84298e070f8 fwd="50.16.79.127" dyno=web.4 connect=1ms service=2ms status=200 bytes=0
```

Would produce the bucket:

bucket1 = {name="l2met-vis.herokuapp.com.service" vals=[2]}
bucket2 = {name="l2met-vis.herokuapp.com.connect" vals=[1]}
bucket3 = {name="l2met-vis.herokuapp.com.bytes" vals=[0]}
