### PR TITLE
bucket attributes

### DIFF
--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -116,7 +116,7 @@ func NewBucket(tok string, rdr *bufio.Reader, opts map[string][]string) <-chan *
 }
 
 var (
-	unitsPat = regexp.MustCompile(`\D+`)
+	unitsPat = regexp.MustCompile(`[a-zA-Z]+`)
 	valPat   = regexp.MustCompile(`\d+`)
 )
 

--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -8,6 +8,7 @@ import (
 	"l2met/encoding"
 	"l2met/utils"
 	"math"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -92,8 +93,8 @@ func NewBucket(tok string, rdr *bufio.Reader, opts map[string][]string) <-chan *
 			for k, v := range logData {
 				switch k {
 				case "measure":
-					val := parseVal(logData["val"])
-					id := &Id{ts, res, tok, v, src}
+					units, val := parseVal(logData["val"])
+					id := &Id{ts, res, tok, v, units, src}
 					bucket := &Bucket{Id: id}
 					bucket.Vals = []float64{val}
 					c <- bucket
@@ -102,8 +103,8 @@ func NewBucket(tok string, rdr *bufio.Reader, opts map[string][]string) <-chan *
 						break
 					}
 					name := k[8:] // len("measure.") == 8
-					val := parseVal(v)
-					id := &Id{ts, res, tok, name, src}
+					units, val := parseVal(v)
+					id := &Id{ts, res, tok, name, units, src}
 					bucket := &Bucket{Id: id}
 					bucket.Vals = []float64{val}
 					c <- bucket
@@ -114,17 +115,31 @@ func NewBucket(tok string, rdr *bufio.Reader, opts map[string][]string) <-chan *
 	return buckets
 }
 
+var (
+	unitsPat = regexp.MustCompile(`\D+`)
+	valPat   = regexp.MustCompile(`\d+`)
+)
+
 // If we can parse a number from the string,
 // we will return that number. Return 1 otherwise.
-func parseVal(s string) float64 {
-	val := float64(1)
-	if len(s) > 0 {
-		v, err := strconv.ParseFloat(s, 64)
+func parseVal(s string) (string, float64) {
+	var units string
+	var val float64
+
+	units = unitsPat.FindString(s)
+	if len(units) == 0 {
+		units = "u"
+	}
+
+	val = float64(1)
+	tmpVal := valPat.FindString(s)
+	if len(tmpVal) > 0 {
+		v, err := strconv.ParseFloat(tmpVal, 64)
 		if err == nil {
 			val = v
 		}
 	}
-	return val
+	return units, val
 }
 
 // Adding bucket a to bucket b copies the vals of bucket b and

--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -80,13 +80,13 @@ func NewBucket(tok string, rdr *bufio.Reader, opts map[string][]string) <-chan *
 					src = logData["host"]
 				}
 				if len(logData["connect"]) > 0 {
-					logData[prefix+"connect"] = strings.Replace(logData["connect"], "ms", "", -1)
+					logData[prefix+"connect"] = logData["connect"]
 				}
 				if len(logData["service"]) > 0 {
-					logData[prefix+"service"] = strings.Replace(logData["service"], "ms", "", -1)
+					logData[prefix+"service"] = logData["service"]
 				}
 				if len(logData["bytes"]) > 0 {
-					logData[prefix+"bytes"] = logData["bytes"]
+					logData[prefix+"bytes"] = logData["bytes"] + "bytes"
 				}
 			}
 

--- a/bucket/id.go
+++ b/bucket/id.go
@@ -2,10 +2,10 @@ package bucket
 
 import (
 	"errors"
+	"l2met/utils"
 	"strconv"
 	"strings"
 	"time"
-	"l2met/utils"
 )
 
 // TODO(ryandotsmith): This is an awful hack.
@@ -19,12 +19,13 @@ type Id struct {
 	Resolution time.Duration
 	Token      string
 	Name       string
+	Units      string
 	Source     string
 }
 
 func ParseId(s string) (*Id, error) {
 	parts := strings.Split(s, keySep)
-	if len(parts) < 4 {
+	if len(parts) < 5 {
 		return nil, errors.New("bucket: Unable to parse bucket key.")
 	}
 
@@ -48,8 +49,9 @@ func ParseId(s string) (*Id, error) {
 	id.Resolution = time.Duration(res)
 	id.Token = parts[2]
 	id.Name = parts[3]
-	if len(parts) > 4 {
-		id.Source = parts[4]
+	id.Units = parts[4]
+	if len(parts) > 5 {
+		id.Source = parts[5]
 	}
 	return id, nil
 }
@@ -59,7 +61,8 @@ func (id *Id) String() string {
 	s += strconv.FormatInt(id.Time.Unix(), 10) + keySep
 	s += strconv.FormatInt(int64(id.Resolution), 10) + keySep
 	s += id.Token + keySep
-	s += id.Name
+	s += id.Name + keySep
+	s += id.Units
 	if len(id.Source) > 0 {
 		s += keySep + id.Source
 	}

--- a/bucket/id_test.go
+++ b/bucket/id_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestParseId(t *testing.T) {
-	id := Id{time.Now(), time.Minute, "token", "name", "source"}
+	id := Id{time.Now(), time.Minute, "token", "name", "units", "source"}
 	expected, err := ParseId(id.String())
 	if err != nil {
 		t.FailNow()
@@ -31,7 +31,7 @@ func TestParseId(t *testing.T) {
 }
 
 func TestParseIdWithoutSource(t *testing.T) {
-	id := Id{time.Now(), time.Minute, "token", "name", ""}
+	id := Id{time.Now(), time.Minute, "token", "name", "units", ""}
 	expected, err := ParseId(id.String())
 	if err != nil {
 		t.FailNow()
@@ -75,7 +75,7 @@ func TestDelaySeconds(t *testing.T) {
 func TestDelayFiveSeconds(t *testing.T) {
 	base := time.Now()
 	id := Id{Resolution: (time.Second * 5), Time: base}
-	actualDelay := id.Delay(base.Add(time.Second * 7))
+	actualDelay := id.Delay(base.Add(time.Second * 10))
 	expectedDelay := int64(2)
 
 	if expectedDelay != actualDelay {

--- a/outlet/bucket_reader.go
+++ b/outlet/bucket_reader.go
@@ -11,7 +11,6 @@ import (
 type BucketReader struct {
 	Store       store.Store
 	Interval    time.Duration
-	Partition   string
 	Ttl         uint64
 	NumOutlets  int
 	NumScanners int
@@ -38,7 +37,7 @@ func (r *BucketReader) scan() {
 		//TODO(ryandotsmith): It is a shame that we have to lock
 		//for each interval. It would be great if we could get a lock
 		//and work for like 1,000 intervals and then relock.
-		p, err := utils.LockPartition(r.Partition, r.Store.MaxPartitions(), r.Ttl)
+		p, err := utils.LockPartition("bucket-reader", r.Store.MaxPartitions(), r.Ttl)
 		if err != nil {
 			continue
 		}

--- a/outlet/bucket_reader.go
+++ b/outlet/bucket_reader.go
@@ -50,7 +50,9 @@ func (r *BucketReader) scan() {
 			if bucket.Id.Time.Before(valid) {
 				r.Inbox <- bucket
 			} else {
-				r.Store.Putback(partition, bucket.Id)
+				if err := r.Store.Putback(partition, bucket.Id); err != nil {
+					fmt.Printf("error=%s\n", err)
+				}
 			}
 		}
 		utils.UnlockPartition(fmt.Sprintf("bucket-reader.%d", p))

--- a/outlet/librato_outlet.go
+++ b/outlet/librato_outlet.go
@@ -16,12 +16,18 @@ import (
 
 var libratoUrl = "https://metrics-api.librato.com/v1/metrics"
 
+type LibratoAttributes struct {
+	Min   int    `json:"display_min"`
+	Units string `json:"display_units_long"`
+}
+
 type LibratoPayload struct {
-	Name   string `json:"name"`
-	Time   int64  `json:"measure_time"`
-	Val    string `json:"value"`
-	Source string `json:"source,omitempty"`
-	Token  string `json:",omitempty"`
+	Name   string             `json:"name"`
+	Time   int64              `json:"measure_time"`
+	Val    string             `json:"value"`
+	Source string             `json:"source,omitempty"`
+	Token  string             `json:",omitempty"`
+	Attr   *LibratoAttributes `json:"attributes,omitempty"`
 }
 
 type LibratoRequest struct {
@@ -87,15 +93,18 @@ func (l *LibratoOutlet) convert() {
 			fmt.Printf("at=bucket-no-vals bucket=%s\n", bucket.Id.Name)
 			continue
 		}
-		l.Conversions <- &LibratoPayload{Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".last", Val: ff(bucket.Last())}
-		l.Conversions <- &LibratoPayload{Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".min", Val: ff(bucket.Min())}
-		l.Conversions <- &LibratoPayload{Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".max", Val: ff(bucket.Max())}
-		l.Conversions <- &LibratoPayload{Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".mean", Val: ff(bucket.Mean())}
-		l.Conversions <- &LibratoPayload{Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".median", Val: ff(bucket.Median())}
-		l.Conversions <- &LibratoPayload{Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".perc95", Val: ff(bucket.P95())}
-		l.Conversions <- &LibratoPayload{Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".perc99", Val: ff(bucket.P99())}
-		l.Conversions <- &LibratoPayload{Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".count", Val: fi(bucket.Count())}
-		l.Conversions <- &LibratoPayload{Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".sum", Val: ff(bucket.Sum())}
+		//TODO(ryandotsmith): This is getting out of control.
+		//We need a succinct way to building payloads.
+		attrs := &LibratoAttributes{Min: 0, Units: bucket.Id.Units}
+		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".last", Val: ff(bucket.Last())}
+		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".min", Val: ff(bucket.Min())}
+		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".max", Val: ff(bucket.Max())}
+		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".mean", Val: ff(bucket.Mean())}
+		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".median", Val: ff(bucket.Median())}
+		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".perc95", Val: ff(bucket.P95())}
+		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".perc99", Val: ff(bucket.P99())}
+		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".count", Val: fi(bucket.Count())}
+		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".sum", Val: ff(bucket.Sum())}
 		fmt.Printf("measure.bucket.conversion.delay=%d\n", bucket.Id.Delay(time.Now()))
 	}
 }

--- a/outlet/librato_outlet.go
+++ b/outlet/librato_outlet.go
@@ -95,7 +95,7 @@ func (l *LibratoOutlet) convert() {
 		}
 		//TODO(ryandotsmith): This is getting out of control.
 		//We need a succinct way to building payloads.
-		countAttr := &LibratoOutlet{Min: 0, Units "count"}
+		countAttr := &LibratoAttributes{Min: 0, Units: "count"}
 		attrs := &LibratoAttributes{Min: 0, Units: bucket.Id.Units}
 		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".last", Val: ff(bucket.Last())}
 		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".min", Val: ff(bucket.Min())}

--- a/outlet/librato_outlet.go
+++ b/outlet/librato_outlet.go
@@ -95,6 +95,7 @@ func (l *LibratoOutlet) convert() {
 		}
 		//TODO(ryandotsmith): This is getting out of control.
 		//We need a succinct way to building payloads.
+		countAttr := &LibratoOutlet{Min: 0, Units "count"}
 		attrs := &LibratoAttributes{Min: 0, Units: bucket.Id.Units}
 		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".last", Val: ff(bucket.Last())}
 		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".min", Val: ff(bucket.Min())}
@@ -103,8 +104,8 @@ func (l *LibratoOutlet) convert() {
 		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".median", Val: ff(bucket.Median())}
 		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".perc95", Val: ff(bucket.P95())}
 		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".perc99", Val: ff(bucket.P99())}
-		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".count", Val: fi(bucket.Count())}
 		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".sum", Val: ff(bucket.Sum())}
+		l.Conversions <- &LibratoPayload{Attr: countAttr, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".count", Val: fi(bucket.Count())}
 		fmt.Printf("measure.bucket.conversion.delay=%d\n", bucket.Id.Delay(time.Now()))
 	}
 }


### PR DESCRIPTION
Most physicists agree that attributing units with numbers is paramount for good reasoning. L2met supports associating units with numbers by appending on a non-digit sequence after the digits. For example:

```
measure.db.get=1ms
```

This will create the following bucket:

bucket = {name="measure.db.get", vals=[1], units="ms"}
