### PR TITLE
db-less authentication

### DIFF
--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -26,7 +26,7 @@ type Bucket struct {
 }
 
 //TODO(ryandotsmith): NewBucket should be broken up. This func is too big.
-func NewBucket(tok string, rdr *bufio.Reader, opts map[string][]string) <-chan *Bucket {
+func NewBucket(user, pass string, rdr *bufio.Reader, opts map[string][]string) <-chan *Bucket {
 	//TODO(ryandotsmith): Can we eliminate the magical number?
 	buckets := make(chan *Bucket, 10000)
 	go func(c chan<- *Bucket) {
@@ -94,7 +94,7 @@ func NewBucket(tok string, rdr *bufio.Reader, opts map[string][]string) <-chan *
 				switch k {
 				case "measure":
 					units, val := parseVal(logData["val"])
-					id := &Id{ts, res, tok, v, units, src}
+					id := &Id{ts, res, user, pass, v, units, src}
 					bucket := &Bucket{Id: id}
 					bucket.Vals = []float64{val}
 					c <- bucket
@@ -104,7 +104,7 @@ func NewBucket(tok string, rdr *bufio.Reader, opts map[string][]string) <-chan *
 					}
 					name := k[8:] // len("measure.") == 8
 					units, val := parseVal(v)
-					id := &Id{ts, res, tok, name, units, src}
+					id := &Id{ts, res, user, pass, name, units, src}
 					bucket := &Bucket{Id: id}
 					bucket.Vals = []float64{val}
 					c <- bucket

--- a/bucket/id.go
+++ b/bucket/id.go
@@ -17,7 +17,8 @@ const keySep = "→"
 type Id struct {
 	Time       time.Time
 	Resolution time.Duration
-	Token      string
+	User       string
+	Pass       string
 	Name       string
 	Units      string
 	Source     string
@@ -47,12 +48,12 @@ func ParseId(s string) (*Id, error) {
 	id := new(Id)
 	id.Time = ts
 	id.Resolution = time.Duration(res)
-	id.Token = parts[2]
-	id.Name = parts[3]
-	id.Units = parts[4]
-	if len(parts) > 5 {
-		id.Source = parts[5]
-	}
+	id.User = parts[2]
+	id.Pass = parts[3]
+	id.Name = parts[4]
+	id.Units = parts[5]
+	if len(parts) > 6 {
+		id.Source = parts[6]
 	return id, nil
 }
 
@@ -60,7 +61,8 @@ func (id *Id) String() string {
 	s := ""
 	s += strconv.FormatInt(id.Time.Unix(), 10) + keySep
 	s += strconv.FormatInt(int64(id.Resolution), 10) + keySep
-	s += id.Token + keySep
+	s += id.User + keySep
+	s += id.Pass + keySep
 	s += id.Name + keySep
 	s += id.Units
 	if len(id.Source) > 0 {

--- a/bucket/id.go
+++ b/bucket/id.go
@@ -54,7 +54,7 @@ func ParseId(s string) (*Id, error) {
 	id.Units = parts[5]
 	if len(parts) > 6 {
 		id.Source = parts[6]
-  }
+	}
 	return id, nil
 }
 

--- a/bucket/id.go
+++ b/bucket/id.go
@@ -54,6 +54,7 @@ func ParseId(s string) (*Id, error) {
 	id.Units = parts[5]
 	if len(parts) > 6 {
 		id.Source = parts[6]
+  }
 	return id, nil
 }
 

--- a/bucket/id_test.go
+++ b/bucket/id_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestParseId(t *testing.T) {
-	id := Id{time.Now(), time.Minute, "token", "name", "units", "source"}
+	id := Id{time.Now(), time.Minute, "user", "pass", "name", "units", "source"}
 	expected, err := ParseId(id.String())
 	if err != nil {
 		t.FailNow()
@@ -20,8 +20,12 @@ func TestParseId(t *testing.T) {
 		fmt.Printf("expected=%d actual=%d\n", "name", expected.Name)
 		t.FailNow()
 	}
-	if expected.Token != "token" {
-		fmt.Printf("expected=%d actual=%d\n", "token", expected.Token)
+	if expected.User != "user" {
+		fmt.Printf("expected=%d actual=%d\n", "user", expected.User)
+		t.FailNow()
+	}
+	if expected.Pass != "pass" {
+		fmt.Printf("expected=%d actual=%d\n", "pass", expected.Pass)
 		t.FailNow()
 	}
 	if expected.Resolution != time.Minute {
@@ -31,7 +35,7 @@ func TestParseId(t *testing.T) {
 }
 
 func TestParseIdWithoutSource(t *testing.T) {
-	id := Id{time.Now(), time.Minute, "token", "name", "units", ""}
+	id := Id{time.Now(), time.Minute, "user", "pass", "name", "units", ""}
 	expected, err := ParseId(id.String())
 	if err != nil {
 		t.FailNow()
@@ -40,8 +44,12 @@ func TestParseIdWithoutSource(t *testing.T) {
 		fmt.Printf("expected=%d actual=%d\n", "name", expected.Name)
 		t.FailNow()
 	}
-	if expected.Token != "token" {
-		fmt.Printf("expected=%d actual=%d\n", "token", expected.Token)
+	if expected.User != "user" {
+		fmt.Printf("expected=%d actual=%d\n", "user", expected.User)
+		t.FailNow()
+	}
+	if expected.Pass != "pass" {
+		fmt.Printf("expected=%d actual=%d\n", "pass", expected.Pass)
 		t.FailNow()
 	}
 	if expected.Resolution != time.Minute {

--- a/main.go
+++ b/main.go
@@ -72,6 +72,7 @@ func recvLogs(w http.ResponseWriter, r *http.Request, recv *receiver.Receiver) {
 	}
 	user, pass, err := utils.ParseAuth(r)
 	if err != nil {
+		fmt.Printf("auth-error=%s\n", err)
 		http.Error(w, "Invalid Request", 400)
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func recvLogs(w http.ResponseWriter, r *http.Request, recv *receiver.Receiver) {
 		http.Error(w, "Invalid Request", 400)
 		return
 	}
-	token, err := utils.ParseToken(r)
+	user, pass, err := utils.ParseAuth(r)
 	if err != nil {
 		http.Error(w, "Invalid Request", 400)
 		return
@@ -81,5 +81,5 @@ func recvLogs(w http.ResponseWriter, r *http.Request, recv *receiver.Receiver) {
 		http.Error(w, "Invalid Request", 400)
 		return
 	}
-	recv.Receive(token, b, r.URL.Query())
+	recv.Receive(user, pass, b, r.URL.Query())
 }

--- a/outlet/librato_outlet.go
+++ b/outlet/librato_outlet.go
@@ -26,8 +26,8 @@ type LibratoPayload struct {
 	Time   int64              `json:"measure_time"`
 	Val    string             `json:"value"`
 	Source string             `json:"source,omitempty"`
-	User   string 			  `json:",omitempty"`
-	Pass   string 			  `json:",omitempty"`
+	User   string             `json:",omitempty"`
+	Pass   string             `json:",omitempty"`
 	Attr   *LibratoAttributes `json:"attributes,omitempty"`
 }
 

--- a/outlet/librato_outlet.go
+++ b/outlet/librato_outlet.go
@@ -26,7 +26,8 @@ type LibratoPayload struct {
 	Time   int64              `json:"measure_time"`
 	Val    string             `json:"value"`
 	Source string             `json:"source,omitempty"`
-	Token  string             `json:",omitempty"`
+	User   string 			  `json:",omitempty"`
+	Pass   string 			  `json:",omitempty"`
 	Attr   *LibratoAttributes `json:"attributes,omitempty"`
 }
 
@@ -97,15 +98,15 @@ func (l *LibratoOutlet) convert() {
 		//We need a succinct way to building payloads.
 		countAttr := &LibratoAttributes{Min: 0, Units: "count"}
 		attrs := &LibratoAttributes{Min: 0, Units: bucket.Id.Units}
-		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".last", Val: ff(bucket.Last())}
-		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".min", Val: ff(bucket.Min())}
-		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".max", Val: ff(bucket.Max())}
-		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".mean", Val: ff(bucket.Mean())}
-		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".median", Val: ff(bucket.Median())}
-		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".perc95", Val: ff(bucket.P95())}
-		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".perc99", Val: ff(bucket.P99())}
-		l.Conversions <- &LibratoPayload{Attr: attrs, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".sum", Val: ff(bucket.Sum())}
-		l.Conversions <- &LibratoPayload{Attr: countAttr, Token: bucket.Id.Token, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".count", Val: fi(bucket.Count())}
+		l.Conversions <- &LibratoPayload{Attr: attrs, User: bucket.Id.User, Pass: bucket.Id.Pass, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".last", Val: ff(bucket.Last())}
+		l.Conversions <- &LibratoPayload{Attr: attrs, User: bucket.Id.User, Pass: bucket.Id.Pass, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".min", Val: ff(bucket.Min())}
+		l.Conversions <- &LibratoPayload{Attr: attrs, User: bucket.Id.User, Pass: bucket.Id.Pass, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".max", Val: ff(bucket.Max())}
+		l.Conversions <- &LibratoPayload{Attr: attrs, User: bucket.Id.User, Pass: bucket.Id.Pass, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".mean", Val: ff(bucket.Mean())}
+		l.Conversions <- &LibratoPayload{Attr: attrs, User: bucket.Id.User, Pass: bucket.Id.Pass, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".median", Val: ff(bucket.Median())}
+		l.Conversions <- &LibratoPayload{Attr: attrs, User: bucket.Id.User, Pass: bucket.Id.Pass, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".perc95", Val: ff(bucket.P95())}
+		l.Conversions <- &LibratoPayload{Attr: attrs, User: bucket.Id.User, Pass: bucket.Id.Pass, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".perc99", Val: ff(bucket.P99())}
+		l.Conversions <- &LibratoPayload{Attr: attrs, User: bucket.Id.User, Pass: bucket.Id.Pass, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".sum", Val: ff(bucket.Sum())}
+		l.Conversions <- &LibratoPayload{Attr: countAttr, User: bucket.Id.User, Pass: bucket.Id.Pass, Time: ft(bucket.Id.Time), Source: bucket.Id.Source, Name: bucket.Id.Name + ".count", Val: fi(bucket.Count())}
 		fmt.Printf("measure.bucket.conversion.delay=%d\n", bucket.Id.Delay(time.Now()))
 	}
 }
@@ -123,16 +124,17 @@ func (l *LibratoOutlet) batch() {
 				delete(batchMap, k)
 			}
 		case payload := <-l.Conversions:
-			_, present := batchMap[payload.Token]
+			index := payload.User + ":" + payload.Pass
+			_, present := batchMap[index]
 			if !present {
-				batchMap[payload.Token] = make([]*LibratoPayload, 1, 300)
-				batchMap[payload.Token][0] = payload
+				batchMap[index] = make([]*LibratoPayload, 1, 300)
+				batchMap[index][0] = payload
 			} else {
-				batchMap[payload.Token] = append(batchMap[payload.Token], payload)
+				batchMap[index] = append(batchMap[index], payload)
 			}
-			if len(batchMap[payload.Token]) == cap(batchMap[payload.Token]) {
-				l.Outbox <- batchMap[payload.Token]
-				delete(batchMap, payload.Token)
+			if len(batchMap[index]) == cap(batchMap[index]) {
+				l.Outbox <- batchMap[index]
+				delete(batchMap, index)
 			}
 		}
 	}
@@ -145,16 +147,25 @@ func (l *LibratoOutlet) outlet() {
 			continue
 		}
 
+		// all buckets in the payload are from the same token/account
+		// we can get the user/pass from any entry in the payload
 		sample := payloads[0]
-		tok := &token.Token{Id: sample.Token}
+		tok := new(token.Token)
 
+		switch {
 		// If a global user/token is provided, use the token for all metrics.
 		// This enable a databaseless librato_outlet.
-		if len(l.User) == 0 || len(l.Pass) == 0 {
-			tok.Get()
-		} else {
+		case len(l.User) > 0 && len(l.Pass) > 0:
 			tok.User = l.User
 			tok.Pass = l.Pass
+		// If user is l2met find credentials from postgres
+		case sample.User == "l2met":
+			tok.Id = l.Pass
+			tok.Get()
+		// you're using librato credentials
+		default:
+			tok.User = sample.User
+			tok.Pass = sample.Pass
 		}
 
 		reqBody := new(LibratoRequest)

--- a/outlet/librato_outlet.go
+++ b/outlet/librato_outlet.go
@@ -10,6 +10,7 @@ import (
 	"l2met/token"
 	"l2met/utils"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 )
@@ -202,7 +203,11 @@ func (l *LibratoOutlet) post(tok *token.Token, body *bytes.Buffer) error {
 		return err
 	}
 	req.Header.Add("Content-Type", "application/json")
-	req.SetBasicAuth(tok.User, tok.Pass)
+	escapedUser, err := url.QueryUnescape(tok.User)
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth(escapedUser, tok.Pass)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/receiver/receiver_test.go
+++ b/receiver/receiver_test.go
@@ -28,7 +28,7 @@ func TestReceive(t *testing.T) {
 
 	opts := map[string][]string{}
 	msg := []byte("81 <190>1 2013-03-27T20:02:24+00:00 hostname token shuttle - - measure=hello val=99\n")
-	recv.Receive("123", msg, opts)
+	recv.Receive("user", "pass", msg, opts)
 	time.Sleep(recv.FlushInterval * 2)
 
 	var buckets []*bucket.Bucket
@@ -61,7 +61,7 @@ func TestReceiveOpts(t *testing.T) {
 
 	opts := map[string][]string{"resolution": []string{"1"}}
 	msg := []byte("81 <190>1 2013-03-27T00:00:01+00:00 hostname token shuttle - - measure=hello val=99\n")
-	recv.Receive("123", msg, opts)
+	recv.Receive("user", "pass", msg, opts)
 	time.Sleep(recv.FlushInterval * 2)
 
 	var buckets []*bucket.Bucket
@@ -96,7 +96,7 @@ func TestReceiveMultiMetrics(t *testing.T) {
 
 	opts := map[string][]string{"resolution": []string{"1000"}}
 	msg := []byte("95 <190>1 2013-03-27T00:00:01+00:00 hostname token shuttle - - measure=hello val=10 measure.db=10\n")
-	recv.Receive("123", msg, opts)
+	recv.Receive("user", "pass", msg, opts)
 	time.Sleep(recv.FlushInterval * 2)
 
 	var buckets []*bucket.Bucket
@@ -129,7 +129,7 @@ func TestReceiveRouter(t *testing.T) {
 
 	opts := map[string][]string{"resolution": []string{"1000"}}
 	msg := []byte("112 <190>1 2013-03-27T00:00:01+00:00 shuttle router token - - host=test.l2met.net service=10ms connect=10ms bytes=45")
-	recv.Receive("123", msg, opts)
+	recv.Receive("user", "pass", msg, opts)
 	time.Sleep(recv.FlushInterval * 2)
 
 	//There are 3 measurements in our logline.

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -5,21 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/kr/fernet"
 	"net/http"
 	"net/url"
 	"os"
 	"strconv"
 	"strings"
 	"time"
-)
-
-// These variables are related to verifying
-// and decrypting authentication headers.
-var (
-	OneHundredYears = time.Hour * 24 * 365 * 100
-	authSecret1     = fernet.MustDecodeKey(os.Getenv("AUTH_SECRET1"))
-	authSecret2     = fernet.MustDecodeKey(os.Getenv("AUTH_SECRET2"))
 )
 
 var (
@@ -130,41 +121,9 @@ func ParseAuth(r *http.Request) (user, pass string, err error) {
 		return
 	}
 
-	//We assume that if the user field of the http basic authentication
-	//header is set to l2met, then we are dealing with the legacy, database
-	//backed authentication mechanism.
-	//TODO(ryandotsmith): Deprecate database backed authentication.
-	if string(userPass[0:6]) == "l2met:" {
-		parts := strings.Split(string(userPass), ":")
-		user = parts[0]
-		pass = parts[1]
-		return
-	}
+	parts := strings.Split(string(userPass), ":")
+	user = parts[0]
+	pass = parts[1]
 
-	//If we have gotten here, we have a signed, db-less authentication request
-	//If we can verify and decrypt, then we will pass the decrypted credentials
-	//to the caller. Most of the time, the username and password will be
-	//credentials to outlet providers. (e.g. Librato creds or Graphite creds)
-	//We care about the validity of those credentials here. If they are wrong,
-	//the metrics will be dropped at the outlet. Keep an eye on http
-	//authentication errors from the log output of the outlets.
-	if s := authSecret1.VerifyAndDecrypt(userPass, OneHundredYears); s != nil {
-		parts := strings.Split(string(s), ":")
-		user = parts[0]
-		pass = parts[1]
-		return
-	}
-
-	//A second authSecret is used so that we can support
-	//multiple shared secrets at a time. This will make it easy
-	//to roll shared secrets.
-	if s := authSecret2.VerifyAndDecrypt(userPass, OneHundredYears); s != nil {
-		parts := strings.Split(string(s), ":")
-		user = parts[0]
-		pass = parts[1]
-		return
-	}
-
-	err = errors.New("End of authentication chain reached.")
 	return
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -102,26 +102,38 @@ func ParseRedisUrl() (string, string, error) {
 	return u.Host, password, nil
 }
 
-func ParseToken(r *http.Request) (string, error) {
+func ParseAuth(r *http.Request) (user string, pass string, err error) {
 	header, ok := r.Header["Authorization"]
 	if !ok {
-		return "", errors.New("Authorization header not set.")
+		err = errors.New("Authorization header not set.")
+		return
 	}
 
 	auth := strings.SplitN(header[0], " ", 2)
 	if len(auth) != 2 {
-		return "", errors.New("Malformed header.")
+		err = errors.New("Malformed header.")
+		return
 	}
 
 	userPass, err := base64.StdEncoding.DecodeString(auth[1])
 	if err != nil {
-		return "", errors.New("Malformed encoding.")
+		err = errors.New("Malformed encoding.")
+		return
 	}
 
 	parts := strings.Split(string(userPass), ":")
-	if len(parts) != 2 {
-		return "", errors.New("Password not supplied.")
+	switch len(parts) {
+	case 1: // new formula
+		// decode into username and password
+		// store username/password with token as key
+		user = ""
+		pass = ""
+	case 2: // old format
+		user = ""
+		pass = ""
+	default:
+		err = errors.New("Password not supplied.")
 	}
 
-	return parts[1], nil
+	return
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -102,7 +102,7 @@ func ParseRedisUrl() (string, string, error) {
 	return u.Host, password, nil
 }
 
-func ParseAuth(r *http.Request) (user string, pass string, err error) {
+func ParseAuth(r *http.Request) (user, pass string, err error) {
 	header, ok := r.Header["Authorization"]
 	if !ok {
 		err = errors.New("Authorization header not set.")
@@ -123,14 +123,14 @@ func ParseAuth(r *http.Request) (user string, pass string, err error) {
 
 	parts := strings.Split(string(userPass), ":")
 	switch len(parts) {
-	case 1: // new formula
+	case 1: // new format
 		// decode into username and password
 		// store username/password with token as key
 		user = ""
 		pass = ""
 	case 2: // old format
-		user = ""
-		pass = ""
+		user = parts[0]
+		pass = parts[1]
 	default:
 		err = errors.New("Password not supplied.")
 	}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"encoding/base64"
 	"bytes"
 	"net/http"
 	"testing"
@@ -25,35 +24,6 @@ func TestParseAuthDBToken(t *testing.T) {
 	}
 
 	if expectedPass != "token" {
-		t.Errorf("expected=%q actual=%q\n", "token", expectedPass)
-	}
-}
-
-func TestParseAuthLibratoCreds(t *testing.T) {
-	var b bytes.Buffer
-	r, err := http.NewRequest("GET", "http://does-not-matter.com", &b)
-	if err != nil {
-		t.Error(err)
-	}
-
-	libratoUser := "ryan@heroku.com"
-	libratoPass := "abc123"
-	tok, err := authSecret1.EncryptAndSign([]byte(libratoUser + ":" + libratoPass))
-	if err != nil {
-		t.Error(err)
-	}
-	r.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString(tok))
-	expectedUser, expectedPass, err := ParseAuth(r)
-
-	if err != nil {
-		t.Error(err)
-	}
-
-	if expectedUser != "ryan@heroku.com" {
-		t.Errorf("expected=%q actual=%q\n", "l2met", expectedUser)
-	}
-
-	if expectedPass != "abc123" {
 		t.Errorf("expected=%q actual=%q\n", "token", expectedPass)
 	}
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,29 +1,71 @@
 package utils
 
 import (
-  "testing"
-  "net/http"
-  "encoding/base64"
+	"encoding/base64"
+	"bytes"
+	"net/http"
+	"testing"
 )
 
 func TestParseAuthDBToken(t *testing.T) {
-  r := new(http.Request)
-  r.SetBasicAuth("l2met", "token")
-  expectedUser, expectedPass, err := utils.ParseAuth(r)
+	var b bytes.Buffer
+	r, err := http.NewRequest("GET", "http://does-not-matter.com", &b)
+	if err != nil {
+		t.Error(err)
+	}
+	r.SetBasicAuth("l2met", "token")
+	expectedUser, expectedPass, err := ParseAuth(r)
 
-  if expectedUser != "l2met" {
-		fmt.Printf("expected=%q actual=%q\n", "l2met", expectedUser)
-		t.FailNow()
-  }
+	if err != nil {
+		t.Error(err)
+	}
 
-  if expectedPass != "token" {
-		fmt.Printf("expected=%q actual=%q\n", "token", expectedPass)
-		t.FailNow()
-  }
+	if expectedUser != "l2met" {
+		t.Errorf("expected=%q actual=%q\n", "l2met", expectedUser)
+	}
+
+	if expectedPass != "token" {
+		t.Errorf("expected=%q actual=%q\n", "token", expectedPass)
+	}
 }
 
-func TestParseAuthLibratoCreds(t *testing.T) {}
+func TestParseAuthLibratoCreds(t *testing.T) {
+	var b bytes.Buffer
+	r, err := http.NewRequest("GET", "http://does-not-matter.com", &b)
+	if err != nil {
+		t.Error(err)
+	}
+
+	libratoUser := "ryan@heroku.com"
+	libratoPass := "abc123"
+	tok, err := authSecret1.EncryptAndSign([]byte(libratoUser + ":" + libratoPass))
+	if err != nil {
+		t.Error(err)
+	}
+	r.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString(tok))
+	expectedUser, expectedPass, err := ParseAuth(r)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if expectedUser != "ryan@heroku.com" {
+		t.Errorf("expected=%q actual=%q\n", "l2met", expectedUser)
+	}
+
+	if expectedPass != "abc123" {
+		t.Errorf("expected=%q actual=%q\n", "token", expectedPass)
+	}
+}
 
 func TestParseAuthNoPassword(t *testing.T) {
-  
+	var b bytes.Buffer
+	r, err := http.NewRequest("GET", "http://does-not-matter.com", &b)
+	if err != nil {
+		t.Error(err)
+	}
+	_, _, err = ParseAuth(r)
+	if err == nil {
+		t.Errorf("Expected ParseAuth to return error when with no creds.")
+	}
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+  "testing"
+  "net/http"
+  "encoding/base64"
+)
+
+func TestParseAuthDBToken(t *testing.T) {
+  r := new(http.Request)
+  r.SetBasicAuth("l2met", "token")
+  expectedUser, expectedPass, err := utils.ParseAuth(r)
+
+  if expectedUser != "l2met" {
+		fmt.Printf("expected=%q actual=%q\n", "l2met", expectedUser)
+		t.FailNow()
+  }
+
+  if expectedPass != "token" {
+		fmt.Printf("expected=%q actual=%q\n", "token", expectedPass)
+		t.FailNow()
+  }
+}
+
+func TestParseAuthLibratoCreds(t *testing.T) {}
+
+func TestParseAuthNoPassword(t *testing.T) {
+  
+}


### PR DESCRIPTION
L2met has a multi-user mode. Multi-user is activated when $LIBRATO_USER and $LIBRATO_TOKEN are not present in the environment. When in multi-user mode, logs are delivered to l2met using a uuid. This uuid must correspond to a set of librato credentials that are currently being stored in a PG database. This is bad for a variety of reason, the least of which is that we depend on a PG solely for this purpose and the current l2met implementation treats PG as a SPOF. Thus we are motivated to serve mutliple librato accounts with a single l2met while not storing credentials or relying on a PG database.

Db-less authentication is the best proposed solution. It assumes that the librato credentials are provided in the HTTP request header of incoming logs. Logs are commonly delivered to l2met via log-shuttle or logplex, both of these transports requires a URL to which the logs will be delivered. This is where the librato credentials will live.

In addition to having librato credentials in the HTTP basic authentication header, we will also  encrypt and sign the librato credentials. Thus knowing a shared secret is required in order to send data to l2met. If we are unable to verify and decrypt the authentication, we drop the HTTP request.
