### PR TITLE
Fixed failing test which assumes UTC time.

### DIFF
--- a/receiver/receiver_test.go
+++ b/receiver/receiver_test.go
@@ -11,7 +11,7 @@ import (
 type testOps map[string][]string
 
 func TestReceiver(t *testing.T) {
-	currentTime := time.Now()
+	currentTime := time.Now().UTC()
 	opts := testOps{"resolution": []string{"60"}, "user": []string{"u"}, "password": []string{"p"}}
 	cases := []struct {
 		Name    string
@@ -125,7 +125,7 @@ func receiveInput(opts testOps, msg []byte) ([]*bucket.Bucket, error) {
 	recv.Receive(msg, opts)
 	time.Sleep(2*recv.FlushInterval)
 
-	future := time.Now().Add(time.Minute)
+	future := time.Now().UTC().Add(time.Minute)
 	ch, err := st.Scan(future)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
So I found an issue with the logic in the receiver test if which leads to test failures when using localtime.

```
% GOPATH=$HOME/Code/go go test l2met/receiver                                                                                                                                                                                                                              2013-06-29 17:00:08 markw ttys006
warning: building out-of-date packages:
    l2met/bucket
    l2met/store
installing these packages with 'go test -i l2met/receiver' will speed future tests.

at=receiver-drop b=2013-06-30 03:00:00 +1000 EST n=2013-06-29 17:00:00 +1000 EST
at=receiver-drop b=2013-06-30 03:00:00 +1000 EST n=2013-06-29 17:00:00 +1000 EST
at=receiver-drop b=2013-06-30 03:00:00 +1000 EST n=2013-06-29 17:00:00 +1000 EST
--- FAIL: TestReceiver (0.02 seconds)
    receiver_test.go:83: case=router actual-len=0 expected-len=3
FAIL
FAIL    l2met/receiver  0.054s
```

Somewhere in the code it is tainting the date without honouring the offset as illustrated in the pattern of the output.

To correct this I made sure the input to the test is UTC times which matches what I would expect in Heroku logs.

Note tests also pass if you pass UTC timezone when running the tests.

```
TZ=UTC GOPATH=$HOME/Code/go go test l2met/receiver
```

I tried to locate how the date in the bucket was getting tainted but I couldn't locate it, this fix mitigates it to some degree however it would be nice to locate the root cause.
