### PR TITLE
Internal Metrics Channel

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -7,24 +7,26 @@ import (
 	"flag"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 )
 
 type D struct {
-	AppName         string
-	Outlet          string
-	RedisHost       string
-	RedisPass       string
-	Secrets         []string
-	BufferSize      int
-	Concurrency     int
-	Port            int
-	NumOutletRetry  int
-	MaxPartitions   uint64
-	FlushtInterval  time.Duration
-	UsingHttpOutlet bool
-	UsingReciever   bool
-	Verbose         bool
+	AppName               string
+	Outlet                string
+	RedisHost             string
+	RedisPass             string
+	Secrets               []string
+	BufferSize            int
+	Concurrency           int
+	Port                  int
+	NumOutletRetry        int
+	MaxPartitions         uint64
+	FlushtInterval        time.Duration
+	EnableInternalMetrics bool
+	UsingHttpOutlet       bool
+	UsingReciever         bool
+	Verbose               bool
 }
 
 // Builds a conf data structure and connects
@@ -65,10 +67,14 @@ func New() *D {
 	flag.BoolVar(&d.UsingReciever, "receiver", true,
 		"Enable the Receiver.")
 
+	flag.BoolVar(&d.EnableInternalMetrics, "metchan", false,
+		"Enable the internal metrics channel.")
+
 	flag.BoolVar(&d.Verbose, "v", false,
 		"Enable verbose log output.")
 
 	d.RedisHost, d.RedisPass, _ = parseRedisUrl(env("REDIS_URL"))
+	d.Secrets = strings.Split(mustenv("SECRETS"), ":")
 
 	return d
 }
@@ -76,6 +82,14 @@ func New() *D {
 // Helper Function
 func env(n string) string {
 	return os.Getenv(n)
+}
+
+func mustenv(n string) string {
+	v := env(n)
+	if len(v) == 0 {
+		panic("Must set: " + n)
+	}
+	return v
 }
 
 // Helper Function

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -16,6 +16,7 @@ type D struct {
 	Outlet                string
 	RedisHost             string
 	RedisPass             string
+	MetchanUrl            *url.URL
 	Secrets               []string
 	BufferSize            int
 	Concurrency           int
@@ -75,6 +76,13 @@ func New() *D {
 
 	d.RedisHost, d.RedisPass, _ = parseRedisUrl(env("REDIS_URL"))
 	d.Secrets = strings.Split(mustenv("SECRETS"), ":")
+
+	if len(env("METCHAN_URL")) > 0 {
+		url, err := url.Parse(env("METCHAN_URL"))
+		if err == nil {
+			d.MetchanUrl = url
+		}
+	}
 
 	return d
 }

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -24,7 +24,6 @@ type D struct {
 	NumOutletRetry        int
 	MaxPartitions         uint64
 	FlushtInterval        time.Duration
-	EnableInternalMetrics bool
 	UsingHttpOutlet       bool
 	UsingReciever         bool
 	Verbose               bool
@@ -67,9 +66,6 @@ func New() *D {
 
 	flag.BoolVar(&d.UsingReciever, "receiver", true,
 		"Enable the Receiver.")
-
-	flag.BoolVar(&d.EnableInternalMetrics, "metchan", false,
-		"Enable the internal metrics channel.")
 
 	flag.BoolVar(&d.Verbose, "v", false,
 		"Enable verbose log output.")

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -12,21 +12,21 @@ import (
 )
 
 type D struct {
-	AppName               string
-	Outlet                string
-	RedisHost             string
-	RedisPass             string
-	MetchanUrl            *url.URL
-	Secrets               []string
-	BufferSize            int
-	Concurrency           int
-	Port                  int
-	NumOutletRetry        int
-	MaxPartitions         uint64
-	FlushtInterval        time.Duration
-	UsingHttpOutlet       bool
-	UsingReciever         bool
-	Verbose               bool
+	AppName         string
+	Outlet          string
+	RedisHost       string
+	RedisPass       string
+	MetchanUrl      *url.URL
+	Secrets         []string
+	BufferSize      int
+	Concurrency     int
+	Port            int
+	NumOutletRetry  int
+	MaxPartitions   uint64
+	FlushtInterval  time.Duration
+	UsingHttpOutlet bool
+	UsingReciever   bool
+	Verbose         bool
 }
 
 // Builds a conf data structure and connects

--- a/main.go
+++ b/main.go
@@ -50,8 +50,10 @@ func main() {
 	case "librato":
 		rdr := outlet.NewBucketReader(cfg.BufferSize,
 			cfg.Concurrency, cfg.FlushtInterval, st)
+		rdr.Mchan = mchan
 		outlet := outlet.NewLibratoOutlet(cfg.BufferSize,
 			cfg.Concurrency, cfg.NumOutletRetry, rdr)
+		outlet.Mchan = mchan
 		outlet.Start()
 		if cfg.Verbose {
 			go outlet.Report()
@@ -61,6 +63,7 @@ func main() {
 			Store:    st,
 			Interval: cfg.FlushtInterval,
 		}
+		rdr.Mchan = mchan
 		outlet := outlet.NewGraphiteOutlet(cfg.BufferSize, rdr)
 		outlet.Start()
 	default:
@@ -81,7 +84,7 @@ func main() {
 	if cfg.UsingReciever {
 		recv := receiver.NewReceiver(cfg.BufferSize,
 			cfg.Concurrency, cfg.FlushtInterval, st)
-		recv.Metchan = mchan
+		recv.Mchan = mchan
 		recv.Start()
 		if cfg.Verbose {
 			go recv.Report()

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 
 	// Can be passed to other modules
 	// as an internal metrics channel.
-	mchan := metchan.New(cfg.EnableInternalMetrics, cfg.Verbose)
+	mchan := metchan.New(cfg.Verbose, cfg.MetchanUrl)
 
 	// The store will be used by receivers and outlets.
 	var st store.Store

--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func main() {
 				v.Add("user", user)
 				v.Add("password", pass)
 				recv.Receive(b, v)
-				mchan.Measure("http-receiver", startReceiveT)
+				mchan.Measure("http.handle", startReceiveT)
 			})
 	}
 

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func main() {
 			cfg.Concurrency, cfg.NumOutletRetry, rdr)
 		outlet.Start()
 		if cfg.Verbose {
-			//go outlet.Report()
+			go outlet.Report()
 		}
 	case "graphite":
 		rdr := &outlet.BucketReader{
@@ -84,7 +84,7 @@ func main() {
 		recv.Metchan = mchan
 		recv.Start()
 		if cfg.Verbose {
-			//go recv.Report()
+			go recv.Report()
 		}
 		http.HandleFunc("/logs",
 			func(w http.ResponseWriter, r *http.Request) {

--- a/metchan/metchan.go
+++ b/metchan/metchan.go
@@ -37,6 +37,12 @@ type Channel struct {
 	url *url.URL
 }
 
+// Returns an initialized Metchan Channel.
+// Creates a new HTTP client for direct access to Librato.
+// This channel is orthogonal with other librato http clients in l2met.
+// If a blank URL is given, no metric posting attempt will be made.
+// If verbose is set to true, the metric will be printed to STDOUT
+// regardless of whether the metric is sent to Librato.
 func New(verbose bool, u *url.URL) *Channel {
 	c := new(Channel)
 	c.url = u
@@ -49,6 +55,9 @@ func New(verbose bool, u *url.URL) *Channel {
 	return c
 }
 
+// Provide the time at which you started your measurement.
+// Places the measurement in a buffer to be aggregated and
+// eventually flushed to Librato.
 func (c *Channel) Measure(name string, t time.Time) {
 	elapsed := time.Since(t) / time.Millisecond
 	if c.verbose {

--- a/metchan/metchan.go
+++ b/metchan/metchan.go
@@ -55,7 +55,6 @@ func New(verbose bool, u *url.URL) *Channel {
 	c.username = u.User.Username()
 	c.password, _ = u.User.Password()
 	c.url.User = nil
-	print(c.url.String())
 
 	go c.scheduleFlush()
 	go c.outlet()

--- a/metchan/metchan.go
+++ b/metchan/metchan.go
@@ -1,0 +1,154 @@
+// An internal metrics channel.
+// l2met internal components can publish their metrics
+// here and they will be outletted to Librato.
+package metchan
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/ryandotsmith/l2met/bucket"
+	"io/ioutil"
+	"net/http"
+	"sync"
+	"time"
+)
+
+var libratoUrl = "https://metrics-api.librato.com/v1/metrics"
+
+// Convert l2met data into Librato's API format.
+type libratoMetric struct {
+	Name   string  `json:"name"`
+	Time   int64   `json:"measure_time"`
+	Source string  `json:"source"`
+	Count  int     `json:"count"`
+	Sum    float64 `json:"sum"`
+	Max    float64 `json:"max"`
+	Min    float64 `json:"min"`
+}
+
+// The channel for which internal metrics are organized.
+type Channel struct {
+	sync.Mutex
+	verbose bool
+	enabled bool
+	buffer  map[bucket.Id]*bucket.Bucket
+	outbox  chan *bucket.Bucket
+}
+
+func New(enabled, verbose bool) *Channel {
+	c := new(Channel)
+	c.enabled = enabled
+	c.verbose = verbose
+	c.buffer = make(map[bucket.Id]*bucket.Bucket)
+	c.outbox = make(chan *bucket.Bucket, 10)
+	go c.scheduleFlush()
+	go c.outlet()
+	return c
+}
+
+func (c *Channel) Measure(name string, t time.Time) {
+	elapsed := time.Since(t) / time.Millisecond
+	if c.verbose {
+		fmt.Printf("measure.%s=%f\n", name, float64(elapsed))
+	}
+	if !c.enabled {
+		return
+	}
+	b := &bucket.Bucket{
+		Id: &bucket.Id{
+			Time:       time.Now().Truncate(time.Minute),
+			Resolution: time.Minute,
+			Name:       name,
+			Units:      "ms",
+			// TODO(ryandotsmith):
+			// Maybe we use the system's hostname?
+			Source:     "metchan",
+		},
+		Vals: []float64{float64(elapsed)},
+	}
+	c.add(b)
+}
+
+func (c *Channel) add(b *bucket.Bucket) {
+	c.Lock()
+	defer c.Unlock()
+	existing, present := c.buffer[*b.Id]
+	if !present {
+		c.buffer[*b.Id] = b
+		return
+	}
+	existing.Add(b)
+}
+
+func (c *Channel) scheduleFlush() {
+	for _ = range time.Tick(time.Second * 5) {
+		c.flush()
+	}
+}
+
+func (c *Channel) flush() {
+	c.Lock()
+	defer c.Unlock()
+	for id, b := range c.buffer {
+		c.outbox <- b
+		delete(c.buffer, id)
+	}
+}
+
+func (c *Channel) outlet() {
+	for b := range c.outbox {
+		met := &libratoMetric{
+			Name:   b.Id.Name,
+			Time:   b.Id.Time.Unix(),
+			Source: b.Id.Source,
+			Count:  b.Count(),
+			Sum:    b.Sum(),
+			Max:    b.Max(),
+			Min:    b.Min(),
+		}
+		if err := post(met); err != nil {
+			fmt.Printf("at=metchan-post error=%s\n", err)
+		} else {
+			fmt.Printf("at=metchan-post status=success\n")
+		}
+	}
+}
+
+func post(m *libratoMetric) error {
+	payload := struct {
+		Gauges []*libratoMetric `json:"gauges"`
+	}{
+		[]*libratoMetric{m},
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest("POST", libratoUrl, bytes.NewBuffer(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("User-Agent", "l2met-metchan/0")
+	req.SetBasicAuth("s@32k.io", "484c793b46dabbf72c24489f88793b65e05664b83e4b0ddce55b051822a008d0")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		var m string
+		s, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			m = fmt.Sprintf("code=%d", resp.StatusCode)
+		} else {
+			m = fmt.Sprintf("code=%d resp=body=%s req-body=%s",
+				resp.StatusCode, s, body)
+		}
+		return errors.New(m)
+	}
+	return nil
+}

--- a/metchan/metchan_test.go
+++ b/metchan/metchan_test.go
@@ -1,0 +1,53 @@
+package metchan
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func serve(a *[]byte) (*url.URL, *httptest.Server) {
+	f := func(w http.ResponseWriter, r *http.Request) {
+		*a, _ = ioutil.ReadAll(r.Body)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(f))
+	u, _ := url.Parse(srv.URL)
+	u.User = url.UserPassword("", "")
+	return u, srv
+}
+
+var metTests = []struct {
+	name  string
+	start time.Time
+}{
+
+	{
+		"simple.test",
+		time.Now(),
+	},
+}
+
+func TestMetchan(t *testing.T) {
+	for _, ts := range metTests {
+		var actual []byte
+		u, srv := serve(&actual)
+		mchan := New(false, u)
+		mchan.FlushInterval = time.Millisecond * 500
+		mchan.Start()
+		mchan.Measure(ts.name, ts.start)
+		time.Sleep(mchan.FlushInterval * 2)
+		srv.Close()
+		p := new(libratoPayload)
+		if err := json.Unmarshal(actual, &p); err != nil {
+			t.Error(err)
+		}
+		if p.Gauges[0].Name != ts.name {
+			t.Errorf("actual=%s expected=%s\n",
+				p.Gauges[0].Name, ts.name)
+		}
+	}
+}

--- a/outlet/bucket_reader.go
+++ b/outlet/bucket_reader.go
@@ -2,6 +2,7 @@ package outlet
 
 import (
 	"fmt"
+	"github.com/ryandotsmith/l2met/metchan"
 	"github.com/ryandotsmith/l2met/bucket"
 	"github.com/ryandotsmith/l2met/store"
 	"time"
@@ -16,6 +17,7 @@ type BucketReader struct {
 	NumScanners int
 	Inbox       chan *bucket.Bucket
 	Outbox      chan *bucket.Bucket
+	Mchan       *metchan.Channel
 }
 
 func NewBucketReader(sz, c int, i time.Duration, st store.Store) *BucketReader {
@@ -39,6 +41,7 @@ func (r *BucketReader) Start(out chan *bucket.Bucket) {
 
 func (r *BucketReader) scan() {
 	for t := range time.Tick(r.Interval) {
+		startScan := time.Now()
 		buckets, err := r.Store.Scan(t)
 		if err != nil {
 			fmt.Printf("at=bucket.scan error=%s\n", err)
@@ -47,12 +50,15 @@ func (r *BucketReader) scan() {
 		for b := range buckets {
 			r.Inbox <- b
 		}
+		r.Mchan.Measure("reader.scan", startScan)
 	}
 }
 
 func (r *BucketReader) outlet() {
 	for b := range r.Inbox {
+		startGet := time.Now()
 		r.Store.Get(b)
 		r.Outbox <- b
+		r.Mchan.Measure("reader.get", startGet)
 	}
 }

--- a/outlet/librato_outlet.go
+++ b/outlet/librato_outlet.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/ryandotsmith/l2met/bucket"
+	"github.com/ryandotsmith/l2met/metchan"
 	"github.com/ryandotsmith/l2met/utils"
 	"io/ioutil"
 	"net"
@@ -72,6 +73,7 @@ type LibratoOutlet struct {
 	rdr Reader
 	// Number of times to retry HTTP requests to librato's api.
 	numRetries int
+	Mchan      *metchan.Channel
 }
 
 func NewLibratoOutlet(sz, concur, retries int, r Reader) *LibratoOutlet {
@@ -198,7 +200,7 @@ func (l *LibratoOutlet) postWithRetry(u, p string, body *bytes.Buffer) error {
 }
 
 func (l *LibratoOutlet) post(u, p string, body *bytes.Buffer) error {
-	defer utils.MeasureT("librato-post", time.Now())
+	defer l.Mchan.Measure("outlet.post", time.Now())
 	req, err := http.NewRequest("POST", libratoUrl, body)
 	if err != nil {
 		return err

--- a/outlet/librato_outlet.go
+++ b/outlet/librato_outlet.go
@@ -1,7 +1,6 @@
 package outlet
 
 import (
-	"runtime"
 	"bytes"
 	"encoding/json"
 	"errors"
@@ -11,6 +10,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"runtime"
 	"time"
 )
 

--- a/outlet/librato_outlet.go
+++ b/outlet/librato_outlet.go
@@ -167,15 +167,18 @@ func (l *LibratoOutlet) outlet() {
 		//Since a playload contains all metrics for
 		//a unique librato user/pass, we can extract the user/pass
 		//from any one of the payloads.
-		sample := payloads[0]
-		reqBody := new(LibratoRequest)
-		reqBody.Gauges = payloads
-		j, err := json.Marshal(reqBody)
+		user := payloads[0].User
+		pass := payloads[0].Pass
+		libratoReq := &LibratoRequest{payloads}
+		j, err := json.Marshal(libratoReq)
 		if err != nil {
-			fmt.Printf("at=json-error error=%s user=%s\n", err, sample.User)
+			fmt.Printf("at=json error=%s user=%s\n", err, user)
 			continue
 		}
-		l.postWithRetry(sample.User, sample.Pass, bytes.NewBuffer(j))
+		body := bytes.NewBuffer(j)
+		if err := l.postWithRetry(user, pass, body); err != nil {
+			fmt.Printf("measure.outlet.drop user=%s\n", user)
+		}
 	}
 }
 

--- a/receiver/receiver.go
+++ b/receiver/receiver.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/ryandotsmith/l2met/bucket"
+	"github.com/ryandotsmith/l2met/metchan"
 	"github.com/ryandotsmith/l2met/store"
 	"github.com/ryandotsmith/l2met/utils"
 	"runtime"
@@ -54,6 +55,8 @@ type Receiver struct {
 	Store store.Store
 	//Count the number of times we accept a bucket.
 	numBuckets uint64
+	// Publish receiver metrics on this channel.
+	Metchan *metchan.Channel
 }
 
 func NewReceiver(sz, c int, i time.Duration, s store.Store) *Receiver {
@@ -147,9 +150,11 @@ func (r *Receiver) transfer() {
 
 func (r *Receiver) outlet() {
 	for b := range r.Outbox {
+		startPut := time.Now()
 		if err := r.Store.Put(b); err != nil {
 			fmt.Printf("error=%s\n", err)
 		}
+		r.Metchan.Measure("reciever.outlet", startPut)
 	}
 }
 

--- a/receiver/receiver.go
+++ b/receiver/receiver.go
@@ -56,7 +56,7 @@ type Receiver struct {
 	//Count the number of times we accept a bucket.
 	numBuckets uint64
 	// Publish receiver metrics on this channel.
-	Metchan *metchan.Channel
+	Mchan *metchan.Channel
 }
 
 func NewReceiver(sz, c int, i time.Duration, s store.Store) *Receiver {
@@ -118,7 +118,7 @@ func (r *Receiver) accept() {
 					bucket.Id.Time, now)
 			}
 		}
-		r.Metchan.Measure("receiver.accept", startParse)
+		r.Mchan.Measure("receiver.accept", startParse)
 	}
 }
 
@@ -156,7 +156,7 @@ func (r *Receiver) outlet() {
 		if err := r.Store.Put(b); err != nil {
 			fmt.Printf("error=%s\n", err)
 		}
-		r.Metchan.Measure("reciever.outlet", startPut)
+		r.Mchan.Measure("reciever.outlet", startPut)
 	}
 }
 

--- a/receiver/receiver.go
+++ b/receiver/receiver.go
@@ -108,6 +108,7 @@ func (r *Receiver) Stop() {
 func (r *Receiver) accept() {
 	for lreq := range r.Inbox {
 		rdr := bufio.NewReader(bytes.NewReader(lreq.Body))
+		startParse := time.Now()
 		for bucket := range bucket.NewBuckets(rdr, lreq.Opts) {
 			now := time.Now().Truncate(bucket.Id.Resolution)
 			if bucket.Id.Time.Equal(now) {
@@ -117,6 +118,7 @@ func (r *Receiver) accept() {
 					bucket.Id.Time, now)
 			}
 		}
+		r.Metchan.Measure("receiver.accept", startParse)
 	}
 }
 

--- a/receiver/receiver_test.go
+++ b/receiver/receiver_test.go
@@ -2,6 +2,7 @@ package receiver
 
 import (
 	"fmt"
+	"github.com/ryandotsmith/l2met/metchan"
 	"github.com/ryandotsmith/l2met/bucket"
 	"github.com/ryandotsmith/l2met/store"
 	"testing"
@@ -129,6 +130,7 @@ func fmtLog(t time.Time, procid, msg string) []byte {
 func receiveInput(opts testOps, msg []byte) ([]*bucket.Bucket, error) {
 	st := store.NewMemStore()
 	recv := NewReceiver(100, 1, time.Millisecond*5, st)
+	recv.Metchan = new(metchan.Channel)
 	recv.Start()
 	defer recv.Stop()
 

--- a/receiver/receiver_test.go
+++ b/receiver/receiver_test.go
@@ -130,7 +130,7 @@ func fmtLog(t time.Time, procid, msg string) []byte {
 func receiveInput(opts testOps, msg []byte) ([]*bucket.Bucket, error) {
 	st := store.NewMemStore()
 	recv := NewReceiver(100, 1, time.Millisecond*5, st)
-	recv.Metchan = new(metchan.Channel)
+	recv.Mchan = new(metchan.Channel)
 	recv.Start()
 	defer recv.Stop()
 

--- a/receiver/receiver_test.go
+++ b/receiver/receiver_test.go
@@ -2,8 +2,8 @@ package receiver
 
 import (
 	"fmt"
-	"github.com/ryandotsmith/l2met/metchan"
 	"github.com/ryandotsmith/l2met/bucket"
+	"github.com/ryandotsmith/l2met/metchan"
 	"github.com/ryandotsmith/l2met/store"
 	"testing"
 	"time"


### PR DESCRIPTION
In regards to #81, this is an implementation of an internal metrics channel. The interface looks like this:

``` go
verbose := false
mchan := metchan.New(verbose, "https://u:p@metrics.librato.com/...")

func hello() {
    defer mchan.Measure("some.function", time.Now())
    return
}
```

This will buffer and send a complex measurement to Librato's API.
