### PR TITLE
master branch breaks if METCHAN_URL not specified

### DIFF
--- a/metchan/metchan.go
+++ b/metchan/metchan.go
@@ -78,8 +78,10 @@ func New(verbose bool, u *url.URL) *Channel {
 }
 
 func (c *Channel) Start() {
-	go c.scheduleFlush()
-	go c.outlet()
+	if c.enabled {
+		go c.scheduleFlush()
+		go c.outlet()
+	}
 }
 
 // Provide the time at which you started your measurement.


### PR DESCRIPTION
```
$ go run main.go                                                       

panic: runtime error: invalid memory address or nil pointer dereference             
[signal 0xb code=0x1 addr=0x8 pc=0x4af2d3]                                          

goroutine 1 [running]:                                                              
net/url.(*URL).String(0x0, 0xc2000ab500, 0x0)                                       
        /usr/local/go/src/pkg/net/url/url.go:445 +0x33                              
github.com/ryandotsmith/l2met/metchan.New(0x655e00, 0x0, 0x0)                       
        /home/matt/.go/src/github.com/ryandotsmith/l2met/metchan/metchan.go:58 +0x40
main.main()                                                                         
        /home/matt/code/l2met/main.go:34 +0x74                                      

goroutine 2 [syscall]:                                                              
exit status 2                                                                       
```

```
$ METCHAN_URL="https://user:password@example.com" go run main.go    
at=initialized-mem-store                                              
```

By the looks of things the meta channel constructed in `main()` is passed around to a few places, so it probably wouldn't be a good idea to pass them a nil reference. I'm a little rusty with go, but am I right in thinking one could create an interface which both `metchan.Channel` and some other `metchan.fake.Channel` could implement to hide the fact a metchan hasn't been configured?
