### PR TITLE
Fix procfile creation in setup script

### DIFF
--- a/setup
+++ b/setup
@@ -82,7 +82,7 @@ else
 	echo "Unable to update config: SECRETS=$secret"
 fi
 
-echo 'web: ./l2met -outlet="librato"' > Procfile
+echo 'web: ./l2met -outlet=true -port=$PORT' > Procfile
 
 git add .
 git commit -am "init"


### PR DESCRIPTION
`-outlet` has been a boolean flag since 89bff968c1e09630fa899e6cd99e584abfd9462c
