### PR TITLE
Added the -receiver=true flag to the Procfile creation step in setup.

### DIFF
--- a/setup
+++ b/setup
@@ -82,7 +82,7 @@ else
 	echo "Unable to update config: SECRETS=$secret"
 fi
 
-echo 'web: ./l2met -outlet=true -port=$PORT' > Procfile
+echo 'web: ./l2met -outlet=true -receiver=true -port=$PORT' > Procfile
 
 git add .
 git commit -am "init"

--- a/setup
+++ b/setup
@@ -82,7 +82,7 @@ else
 	echo "Unable to update config: SECRETS=$secret"
 fi
 
-echo 'web: ./l2met -outlet=true -receiver=true -port=$PORT' > Procfile
+echo 'web: ./l2met -outlet -receiver -port=$PORT' > Procfile
 
 git add .
 git commit -am "init"


### PR DESCRIPTION
Added the `-receiver=true` flag into the echo for Procfile creation in the setup script. Having this flag unset was causing the /logs endpoint to be inactive, so the l2met app created by the setup script on Heroku was unable to receive logging data from a syslog drain. 
