### PR TITLE
Include redis in the getting started commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Before working on a new feature, send your proposal to the [mailing list](https:
 ### Running Tests
 [![Build Status](https://drone.io/github.com/ryandotsmith/l2met/status.png)](https://drone.io/github.com/ryandotsmith/l2met/latest)
 ```bash
+$ ./redis-server --version
+Redis server v=2.6.14 sha=f2f2b4eb:0 malloc=libc bits=64
 $ go version
 go version go1.1.1 darwin/amd64
 ```
@@ -51,5 +53,7 @@ $ git clone git://github.com/ryandotsmith/l2met.git
 $ cd l2met
 $ export SECRETS=$(dd if=/dev/urandom bs=32 count=1 2>/dev/null | openssl base64)
 $ export TZ=UTC
+$ export REDIS_URL=redis://localhost:6379
+$ ./redis-server &
 $ go test ./...
 ```


### PR DESCRIPTION
This is really just an attempt to work our a flow by which people with private forks of l2met, when collabed on the ryandotsmith/l2met repo, can submit upstream changes. The steps I took:
1. Create a private l2met repo on github. e.g. private/l2met
2. Clone ryandotsmith/l2met repo
3. Set private/l2met as "origin" in .git/config
4. Set ryandotsmith/l2met as "upstream" in .git/config
5. $ git fetch
6. $ git rebase upstream/master
7. $ git checkout -b new-feature
8. $ git push upstream new-feature

This assumes that you have collab access to ryandotsmith/l2met. I don't have a workaround without granting collab access :(
