### PR TITLE
Improvement: Only read data valid data from redis.

### DIFF
--- a/bucket/id.go
+++ b/bucket/id.go
@@ -3,17 +3,29 @@ package bucket
 import (
 	"bytes"
 	"encoding/gob"
+	"hash/crc64"
 	"time"
 )
+
+var partitionTable = crc64.MakeTable(crc64.ISO)
 
 type Id struct {
 	Time       time.Time
 	Resolution time.Duration
 	Auth       string
+	ReadyAt    time.Time
 	Name       string
 	Units      string
 	Source     string
 	Type       string
+}
+
+func (id *Id) Partition(max uint64) uint64 {
+	b, err := id.Encode()
+	if err != nil {
+		panic(err)
+	}
+	return crc64.Checksum(b, partitionTable) % max
 }
 
 func (id *Id) Decode(b *bytes.Buffer) error {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -146,6 +146,7 @@ func (p *parser) buildId(id *bucket.Id, t *tuple) {
 	id.Resolution = p.Resolution()
 	id.Time = p.Time()
 	id.Auth = p.Auth()
+	id.ReadyAt = id.Time.Add(id.Resolution).Truncate(id.Resolution)
 	id.Name = p.Prefix(t.Name())
 	id.Units = t.Units()
 	id.Source = p.SourcePrefix(p.ld.Source())

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -40,9 +40,9 @@ func (r *Reader) Start(out chan *bucket.Bucket) {
 }
 
 func (r *Reader) scan() {
-	for t := range time.Tick(r.scanInterval) {
+	for _ = range time.Tick(r.scanInterval) {
 		startScan := time.Now()
-		buckets, err := r.str.Scan(t)
+		buckets, err := r.str.Scan(r.str.Now())
 		if err != nil {
 			fmt.Printf("at=bucket.scan error=%s\n", err)
 			continue

--- a/receiver/receiver.go
+++ b/receiver/receiver.go
@@ -124,7 +124,7 @@ func (r *Receiver) accept() {
 		rdr := bufio.NewReader(bytes.NewReader(lreq.Body))
 		startParse := time.Now()
 		for bucket := range parser.BuildBuckets(rdr, lreq.Opts) {
-			if bucket.Id.Delay(time.Now()) <= r.deadline {
+			if bucket.Id.Delay(r.Store.Now()) <= r.deadline {
 				r.addRegister(bucket)
 			} else {
 				r.Mchan.Measure("receiver.drop", 1)

--- a/store/mem_store.go
+++ b/store/mem_store.go
@@ -24,6 +24,10 @@ func (m *MemStore) MaxPartitions() uint64 {
 	return uint64(1)
 }
 
+func (m *MemStore) Now() time.Time {
+	return time.Now()
+}
+
 func (m *MemStore) Scan(schedule time.Time) (<-chan *bucket.Bucket, error) {
 	m.Lock()
 	//TODO(ryandotsmith): Can we eliminate the magical number?

--- a/store/store.go
+++ b/store/store.go
@@ -12,5 +12,6 @@ type Store interface {
 	Put(*bucket.Bucket) error
 	Get(*bucket.Bucket) error
 	Scan(time.Time) (<-chan *bucket.Bucket, error)
+	Now() time.Time
 	Health() bool
 }


### PR DESCRIPTION
Currently the l2met outlet will read a list of buckets ids
from a partition set, select bucket ids for which their time
has come, then put back the buckets who are not ripe. This filtering
means that data comes across the wire, is filtered and then must be put
back one-by-one. The filtering is not that big of a deal, it is the putting
back that makes this situation not ideal.

This change modifies the partition data structure in Redis. When buckets
are RPUSHed into Redis, the key (or Id) of that bucket is added to a set.
They key which describes the set now includes a timestamp. E.g.

```
ts.partition.outlet.N
```

The dynamic parts of the key are **ts** and **N**. The UNIX timestamp (ts)
indicates when the bucket will be ready for processing. **N** represents
the partition to which the bucket belongs. The timestamp is computed by the
following formulate:

```
readyAt = truncate(bucketTime + bucketResolution)
```

E.g.

```
bucketTime = 1376285311
bucketResolution = 60
readyAt = 1376285340
```

Finally, it is not clear that this technique will work in all situations.
We are depending on our outlets to never miss a tick. That is, the outlets
must process buckets that are ready potentially every second. More thought
and testing is required before this patch can be trusted.
