### PR TITLE
Security Fix: Decrypt Librato Creds JIT.

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -8,19 +8,7 @@ import (
 	"testing"
 )
 
-func TestParseNoPassword(t *testing.T) {
-	var b bytes.Buffer
-	r, err := http.NewRequest("GET", "http://does-not-matter.com", &b)
-	if err != nil {
-		t.Error(err)
-	}
-	_, _, err = ParseAndDecrypt(r)
-	if err == nil {
-		t.Errorf("Expected Parse to return error when with no creds.")
-	}
-}
-
-func TestParseEncryptedAuth(t *testing.T) {
+func TestAuth(t *testing.T) {
 	if len(keys) == 0 {
 		t.Fatalf("Must set $SECRETS\n")
 	}
@@ -31,25 +19,31 @@ func TestParseEncryptedAuth(t *testing.T) {
 		t.Error(err)
 	}
 
-	u := "ryan@heroku.com"
-	p := "abc123"
-	tok, err := fernet.EncryptAndSign([]byte(u+":"+p), keys[0])
+	expectedUser := "ryan@heroku.com"
+	expectedPass := "abc123"
+	tok, err := fernet.EncryptAndSign([]byte(expectedUser+":"+expectedPass),
+		keys[0])
 	if err != nil {
 		t.Error(err)
 	}
 	r.Header.Set("Authorization",
 		"Basic "+base64.StdEncoding.EncodeToString(tok))
 
-	expectedUser, expectedPass, err := ParseAndDecrypt(r)
+	parseRes, err := Parse(r.Header["Authorization"][0])
 	if err != nil {
-		t.Error(err)
+		t.Fatalf("error=%s\n", err)
 	}
 
-	if expectedUser != u {
-		t.Errorf("expected=%q actual=%q\n", u, expectedUser)
+	actualUser, actualPass, err := Decrypt(parseRes)
+	if err != nil {
+		t.Fatalf("error=%s\n", err)
 	}
 
-	if expectedPass != p {
-		t.Errorf("expected=%q actual=%q\n", p, expectedPass)
+	if actualUser != expectedUser {
+		t.Fatalf("actual=%q expected=%q\n", actualUser, expectedUser)
+	}
+
+	if actualPass != expectedPass {
+		t.Fatalf("actual=%q expected=%q\n", actualPass, expectedPass)
 	}
 }

--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -25,8 +25,7 @@ type LibratoMetric struct {
 	Time   int64         `json:"measure_time"`
 	Val    float64       `json:"value"`
 	Source string        `json:"source,omitempty"`
-	User   string        `json:"-"`
-	Pass   string        `json:"-"`
+	Auth   string        `json:"-"`
 	Attr   *libratoAttrs `json:"attributes,omitempty"`
 }
 
@@ -99,8 +98,7 @@ func (b *Bucket) Metric(name string, val float64) *LibratoMetric {
 		Name:   b.Id.Name + "." + name,
 		Source: b.Id.Source,
 		Time:   b.Id.Time.Unix(),
-		User:   b.Id.User,
-		Pass:   b.Id.Pass,
+		Auth:   b.Id.Auth,
 		Val:    val,
 	}
 }

--- a/bucket/id.go
+++ b/bucket/id.go
@@ -9,8 +9,7 @@ import (
 type Id struct {
 	Time       time.Time
 	Resolution time.Duration
-	User       string
-	Pass       string
+	Auth       string
 	Name       string
 	Units      string
 	Source     string

--- a/main_test.go
+++ b/main_test.go
@@ -16,8 +16,7 @@ type testOps map[string][]string
 var currentTime = time.Now()
 var opts = testOps{
 	"resolution": []string{"60"},
-	"user":       []string{"u"},
-	"password":   []string{"p"},
+	"auth":       []string{"abc123"},
 }
 
 var integrationTest = []struct {
@@ -31,9 +30,9 @@ var integrationTest = []struct {
 		opts,
 		fmtLog(currentTime, "router", "host=l2met.net connect=1ms service=4ms bytes=10"),
 		[]*bucket.Bucket{
-			build("router.connect", "", "u", "p", currentTime, time.Minute, []float64{1}),
-			build("router.service", "", "u", "p", currentTime, time.Minute, []float64{4}),
-			build("router.bytes", "", "u", "p", currentTime, time.Minute, []float64{10}),
+			build("router.connect", "", "u", currentTime, time.Minute, []float64{1}),
+			build("router.service", "", "u", currentTime, time.Minute, []float64{4}),
+			build("router.bytes", "", "u", currentTime, time.Minute, []float64{10}),
 		},
 	},
 	{
@@ -41,9 +40,9 @@ var integrationTest = []struct {
 		opts,
 		fmtLog(currentTime, "router", "host=l2met.net connect=12345678912ms service=4ms bytes=12345678912"),
 		[]*bucket.Bucket{
-			build("router.connect", "", "u", "p", currentTime, time.Minute, []float64{12345678912}),
-			build("router.service", "", "u", "p", currentTime, time.Minute, []float64{4}),
-			build("router.bytes", "", "u", "p", currentTime, time.Minute, []float64{12345678912}),
+			build("router.connect", "", "u", currentTime, time.Minute, []float64{12345678912}),
+			build("router.service", "", "u", currentTime, time.Minute, []float64{4}),
+			build("router.bytes", "", "u", currentTime, time.Minute, []float64{12345678912}),
 		},
 	},
 	{
@@ -51,7 +50,7 @@ var integrationTest = []struct {
 		opts,
 		fmtLog(currentTime, "app", "measure.a"),
 		[]*bucket.Bucket{
-			build("a", "", "u", "p", currentTime, time.Minute, []float64{1}),
+			build("a", "", "u", currentTime, time.Minute, []float64{1}),
 		},
 	},
 	{
@@ -59,7 +58,7 @@ var integrationTest = []struct {
 		opts,
 		fmtLog(currentTime, "app", "measure#a"),
 		[]*bucket.Bucket{
-			build("a", "", "u", "p", currentTime, time.Minute, []float64{1}),
+			build("a", "", "u", currentTime, time.Minute, []float64{1}),
 		},
 	},
 	{
@@ -67,7 +66,7 @@ var integrationTest = []struct {
 		opts,
 		fmtLog(currentTime, "app", "measure#a"),
 		[]*bucket.Bucket{
-			build("a", "", "u", "p", currentTime, time.Second, []float64{1}),
+			build("a", "", "u", currentTime, time.Second, []float64{1}),
 		},
 	},
 	{
@@ -75,7 +74,7 @@ var integrationTest = []struct {
 		opts,
 		fmtLog(currentTime, "app", "measure#a=1"),
 		[]*bucket.Bucket{
-			build("a", "", "u", "p", currentTime, time.Minute, []float64{1}),
+			build("a", "", "u", currentTime, time.Minute, []float64{1}),
 		},
 	},
 	{
@@ -83,7 +82,7 @@ var integrationTest = []struct {
 		opts,
 		fmtLog(currentTime, "app", "measure#a=0.001"),
 		[]*bucket.Bucket{
-			build("a", "", "u", "p", currentTime, time.Minute, []float64{0.001}),
+			build("a", "", "u", currentTime, time.Minute, []float64{0.001}),
 		},
 	},
 	{
@@ -91,8 +90,8 @@ var integrationTest = []struct {
 		opts,
 		fmtLog(currentTime, "app", "measure#a=1 measure#b=2"),
 		[]*bucket.Bucket{
-			build("a", "", "u", "p", currentTime, time.Minute, []float64{1}),
-			build("b", "", "u", "p", currentTime, time.Minute, []float64{2}),
+			build("a", "", "u", currentTime, time.Minute, []float64{1}),
+			build("b", "", "u", currentTime, time.Minute, []float64{2}),
 		},
 	},
 	{
@@ -100,7 +99,7 @@ var integrationTest = []struct {
 		opts,
 		fmtLog(currentTime, "app", "count#a=1"),
 		[]*bucket.Bucket{
-			build("a", "", "u", "p", currentTime, time.Minute, []float64{1}),
+			build("a", "", "u", currentTime, time.Minute, []float64{1}),
 		},
 	},
 	{
@@ -108,15 +107,15 @@ var integrationTest = []struct {
 		opts,
 		fmtLog(currentTime, "app", "sample#a=1"),
 		[]*bucket.Bucket{
-			build("a", "", "u", "p", currentTime, time.Minute, []float64{1}),
+			build("a", "", "u", currentTime, time.Minute, []float64{1}),
 		},
 	},
 	{
 		"source prefix",
-		testOps{"user": []string{"u"}, "password": []string{"p"}, "source-prefix": []string{"srcpre"}},
+		testOps{"auth": []string{"abc123"}, "source-prefix": []string{"srcpre"}},
 		fmtLog(currentTime, "app", "measure#hello"),
 		[]*bucket.Bucket{
-			build("hello", "srcpre", "u", "p", currentTime, time.Minute, []float64{1}),
+			build("hello", "srcpre", "u", currentTime, time.Minute, []float64{1}),
 		},
 	},
 }
@@ -147,12 +146,11 @@ func TestReceiver(t *testing.T) {
 	}
 }
 
-func build(name, source, user, pass string, t time.Time, res time.Duration, vals []float64) *bucket.Bucket {
+func build(name, source, auth string, t time.Time, res time.Duration, vals []float64) *bucket.Bucket {
 	id := new(bucket.Id)
 	id.Name = name
 	id.Source = source
-	id.User = user
-	id.Pass = pass
+	id.Auth = auth
 	id.Time = t.Truncate(res)
 	id.Resolution = res
 	return &bucket.Bucket{Id: id, Vals: vals}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -145,8 +145,7 @@ func (p *parser) handleHkRouter(t *tuple) error {
 func (p *parser) buildId(id *bucket.Id, t *tuple) {
 	id.Resolution = p.Resolution()
 	id.Time = p.Time()
-	id.User = p.User()
-	id.Pass = p.Pass()
+	id.Auth = p.Auth()
 	id.Name = p.Prefix(t.Name())
 	id.Units = t.Units()
 	id.Source = p.SourcePrefix(p.ld.Source())
@@ -185,12 +184,8 @@ func (p *parser) Prefix(suffix string) string {
 	return pre[0] + "." + suffix
 }
 
-func (p *parser) User() string {
-	return p.opts["user"][0]
-}
-
-func (p *parser) Pass() string {
-	return p.opts["password"][0]
+func (p *parser) Auth() string {
+	return p.opts["auth"][0]
 }
 
 func (p *parser) Time() time.Time {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -16,13 +16,13 @@ var parseTest = []struct {
 	{
 		"simple",
 		`88 <174>1 2013-07-22T00:06:26-00:00 somehost name test - measure#hello=1 measure#world=1ms\n`,
-		options{"user": []string{"u"}, "password": []string{"p"}},
+		options{"auth": []string{"abc123"}},
 		[]string{"hello", "world"},
 	},
 	{
 		"legacy",
 		`70 <174>1 2013-07-22T00:06:26-00:00 somehost name test - measure.hello=1\n`,
-		options{"user": []string{"u"}, "password": []string{"p"}},
+		options{"auth": []string{"abc123"}},
 		[]string{"hello"},
 	},
 }


### PR DESCRIPTION
Applies to all versions of l2met using the Redis store.

L2met makes HTTP requests to the Librato API on behalf of the
l2met user. L2met does not store the user's Librato credentials
in a long term database. When l2met receives an HTTP request containing
log data, it parses the authorization header, decrypts the header, and
extracts the librato username and password. L2met then keeps the username
and password assoicaited with the log data. This means that the Librato
username and password get passed through Redis on their way to the Librato
outlet and Librato API.

This patch keeps the username and password in their encrypted form
during the Redis phase of the data flow. HTTP requests sent to l2met
are decrypted, but the result is not cached. Instead, the encrypted data
is passed through the system. It is only at the time we make the Librato
HTTP request that we extract the Librato username & password.
